### PR TITLE
#7 add label for consistent mass deletion of CES K8s resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- #7 add/update label for consistent mass deletion of CES K8s resources
+   - select any k8s-dogu-operator related resources like this: `kubectl get deploy,pod,dogu,rolebinding,... -l app=ces,app.kubernetes.io/name=k8s-dogu-operator`
+   - select all CES components like this: `kubectl get deploy,pod,dogu,rolebinding,... -l app=ces`
+  
 ### Added
 
 - Add release mechanism #5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - #7 add/update label for consistent mass deletion of CES K8s resources
-   - select any k8s-dogu-operator related resources like this: `kubectl get deploy,pod,dogu,rolebinding,... -l app=ces,app.kubernetes.io/name=k8s-dogu-operator`
+   - select any etcd related resources like this: `kubectl get deploy,pod,dogu,rolebinding,... -l app=ces,app.kubernetes.io/name=etcd`
    - select all CES components like this: `kubectl get deploy,pod,dogu,rolebinding,... -l app=ces`
   
 ### Added

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -124,6 +124,9 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        labels:
+          app: ces
+          app.kubernetes.io/name: etcd
       spec:
         accessModes:
           - "ReadWriteOnce"


### PR DESCRIPTION
kustomization takes a different approach to adding label than regular resource YAMLs, so this commit makes amends as the previous commits missed to add labels on generated ConfigMaps.