### PR TITLE
#9 Decrease initial delay for ready probe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- #9 Change the initial seconds to start the ready probe to 0s.
+  -  The old value (60s) causes a slow ready state for the pod.
+  -  Actual startup of the etcd is much faster than that.
+
 ## [v3.5.4-1] - 2023-01-11
 
 ### Changed

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -113,7 +113,6 @@ spec:
             exec:
               command:
                 - /opt/bitnami/scripts/etcd/healthcheck.sh
-            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 5
             successThreshold: 1


### PR DESCRIPTION
The actual startup of the etcd is much faster than the old initial delay to start the ready probe. With this change the etcd accept request earlier and causes a faster setup.

Resolves #9 