### PR TITLE
Stabilise etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- #11 Use correct advertise url to decrease startup time for the initial cluster creation.
+  - Increase the delay of the readinessprobe to 10 seconds because the regular startup lasts 3 seconds.
+- Add a headless service for the pods of the statefulset.
+- Upgrade etcd to etcd:3.5.7-debian-11-r22.
 
 ## [v3.5.4-2] - 2023-01-13
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 ARTIFACT_ID=k8s-etcd
 VERSION=3.5.4-2
-MAKEFILES_VERSION=7.0.1
+MAKEFILES_VERSION=7.5.0
 
 include build/make/variables.mk
 include build/make/k8s.mk
 include build/make/clean.mk
+include build/make/self-update.mk
 
 ##@ Release
 

--- a/build/make/k8s-controller.mk
+++ b/build/make/k8s-controller.mk
@@ -83,12 +83,12 @@ k8s-integration-test: $(K8S_INTEGRATION_TEST_DIR) manifests generate envtest ## 
 CONTROLLER_GEN = $(UTILITY_BIN_PATH)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3)
 
 KUSTOMIZE = $(UTILITY_BIN_PATH)/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.7)
 
 ENVTEST = $(UTILITY_BIN_PATH)/setup-envtest
 .PHONY: envtest

--- a/build/make/k8s-dogu.mk
+++ b/build/make/k8s-dogu.mk
@@ -28,7 +28,7 @@ K8S_RESOURCE_PRODUCTIVE_YAML ?= $(K8S_RESOURCE_PRODUCTIVE_FOLDER)/$(ARTIFACT_ID)
 K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 # The pre generation script creates a k8s resource yaml containing the dogu crd and the content from the k8s folder.
 .PHONY: k8s-create-temporary-resource
- k8s-create-temporary-resource: ${BINARY_YQ}
+ k8s-create-temporary-resource: ${BINARY_YQ} $(K8S_RESOURCE_TEMP_FOLDER)
 	@echo "Generating temporary K8s resources $(K8S_RESOURCE_TEMP_YAML)..."
 	@rm -f $(K8S_RESOURCE_TEMP_YAML)
 	@sed "s|NAMESPACE|$(ARTIFACT_NAMESPACE)|g" $(K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML) | sed "s|NAME|$(ARTIFACT_ID)|g"  | sed "s|VERSION|$(VERSION)|g" >> $(K8S_RESOURCE_TEMP_YAML)
@@ -40,5 +40,5 @@ K8S_RESOURCE_DOGU_CR_TEMPLATE_YAML ?= $(WORKDIR)/build/make/k8s-dogu.tpl
 install-dogu-descriptor: ${BINARY_YQ} $(TARGET_DIR) ## Installs a configmap with current dogu.json into the cluster.
 	@echo "Generate configmap from dogu.json..."
 	@$(BINARY_YQ) ".Image=\"${IMAGE_DEV_WITHOUT_TAG}\"" ${DOGU_JSON_FILE} > ${DOGU_JSON_DEV_FILE}
-	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f -
+	@kubectl create configmap "$(ARTIFACT_ID)-descriptor" --from-file=$(DOGU_JSON_DEV_FILE) --dry-run=client -o yaml | kubectl apply -f - --namespace=${NAMESPACE}
 	@echo "Done."

--- a/build/make/k8s.mk
+++ b/build/make/k8s.mk
@@ -8,8 +8,6 @@ endif
 
 BINARY_YQ = $(UTILITY_BIN_PATH)/yq
 
-# The cluster root variable is used to the build images to the cluster. It can be defined in a .myenv file.
-K8S_CLUSTER_ROOT ?=
 # The productive tag of the image
 IMAGE ?=
 
@@ -22,17 +20,14 @@ K3CES_REGISTRY_URL_PREFIX="${K3S_CLUSTER_FQDN}:${K3S_LOCAL_REGISTRY_PORT}"
 K8S_RESOURCE_TEMP_FOLDER ?= $(TARGET_DIR)/make/k8s
 K8S_RESOURCE_TEMP_YAML ?= $(K8S_RESOURCE_TEMP_FOLDER)/$(ARTIFACT_ID)_$(VERSION).yaml
 
-# The current namespace is extracted from the current context.
-K8S_CURRENT_NAMESPACE=$(shell kubectl config view --minify -o jsonpath='{..namespace}')
-
 ##@ K8s - Variables
 
 .PHONY: check-all-vars
-check-all-vars: check-k8s-cluster-root-env-var check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry ## Conduct a sanity check against selected build artefacts or local environment
+check-all-vars: check-k8s-image-env-var check-k8s-artifact-id check-etc-hosts check-insecure-cluster-registry check-k8s-namespace-env-var ## Conduct a sanity check against selected build artefacts or local environment
 
-.PHONY: check-k8s-cluster-root-env-var
-check-k8s-cluster-root-env-var:
-	@$(call check_defined, K8S_CLUSTER_ROOT, root path of your k3ces)
+.PHONY: check-k8s-namespace-env-var
+check-k8s-namespace-env-var:
+	@$(call check_defined, NAMESPACE, k8s namespace)
 
 .PHONY: check-k8s-image-env-var
 check-k8s-image-env-var:
@@ -60,7 +55,7 @@ ${K8S_RESOURCE_TEMP_FOLDER}:
 .PHONY: k8s-delete
 k8s-delete: k8s-generate $(K8S_POST_GENERATE_TARGETS) ## Deletes all dogu related resources from the K8s cluster.
 	@echo "Delete old dogu resources..."
-	@kubectl delete -f $(K8S_RESOURCE_TEMP_YAML) --wait=false --ignore-not-found=true
+	@kubectl delete -f $(K8S_RESOURCE_TEMP_YAML) --wait=false --ignore-not-found=true --namespace=${NAMESPACE}
 
 # The additional targets executed after the generate target, executed before each apply and delete. The generate target
 # produces a temporary yaml. This yaml is accessible via K8S_RESOURCE_TEMP_YAML an can be changed before the apply/delete.
@@ -71,14 +66,14 @@ K8S_PRE_GENERATE_TARGETS ?= k8s-create-temporary-resource
 .PHONY: k8s-generate
 k8s-generate: ${BINARY_YQ} $(K8S_RESOURCE_TEMP_FOLDER) $(K8S_PRE_GENERATE_TARGETS) ## Generates the final resource yaml.
 	@echo "Applying general transformations..."
-	@sed -i "s/'{{ .Namespace }}'/$(K8S_CURRENT_NAMESPACE)/" $(K8S_RESOURCE_TEMP_YAML)
+	@sed -i "s/'{{ .Namespace }}'/$(NAMESPACE)/" $(K8S_RESOURCE_TEMP_YAML)
 	@$(BINARY_YQ) -i e "(select(.kind == \"Deployment\").spec.template.spec.containers[]|select(.image == \"*$(ARTIFACT_ID)*\").image)=\"$(IMAGE_DEV)\"" $(K8S_RESOURCE_TEMP_YAML)
 	@echo "Done."
 
 .PHONY: k8s-apply
 k8s-apply: k8s-generate $(K8S_POST_GENERATE_TARGETS) ## Applies all generated K8s resources to the current cluster and namespace.
 	@echo "Apply generated K8s resources..."
-	@kubectl apply -f $(K8S_RESOURCE_TEMP_YAML)
+	@kubectl apply -f $(K8S_RESOURCE_TEMP_YAML) --namespace=${NAMESPACE}
 
 ##@ K8s - Docker
 

--- a/build/make/mockery.yaml
+++ b/build/make/mockery.yaml
@@ -1,0 +1,4 @@
+inpackage: True
+testonly: True
+with-expecter: True
+keeptree: False

--- a/build/make/mocks.mk
+++ b/build/make/mocks.mk
@@ -1,0 +1,27 @@
+##@ Mocking
+
+MOCKERY_BIN=${UTILITY_BIN_PATH}/mockery
+MOCKERY_VERSION=v2.20.0
+MOCKERY_YAML=${WORKDIR}/.mockery.yaml
+
+${MOCKERY_BIN}: ${UTILITY_BIN_PATH}
+	$(call go-get-tool,$(MOCKERY_BIN),github.com/vektra/mockery/v2@$(MOCKERY_VERSION))
+
+${MOCKERY_YAML}:
+	@cp ${WORKDIR}/build/make/mockery.yaml ${WORKDIR}/.mockery.yaml
+
+.PHONY: mocks
+mocks: ${MOCKERY_BIN} ${MOCKERY_YAML} ## This target is used to generate mocks for all interfaces in a project.
+	@for dir in ${WORKDIR}/*/ ;\
+ 		do \
+ 		# removes trailing '/' \
+		dir=$${dir%*/} ;\
+		# removes everything before the last '/' \
+		dir=$${dir##*/} ;\
+		if ! echo '${MOCKERY_IGNORED}' | egrep -q "\b$${dir}\b" ;\
+		then \
+		  	echo "Creating mocks for $${dir}" ;\
+			${MOCKERY_BIN} --all --dir $${dir} ;\
+		fi ;\
+ 	done ;
+	@echo "Mocks successfully created."

--- a/build/make/variables.mk
+++ b/build/make/variables.mk
@@ -19,7 +19,7 @@ GO_BUILD_TAG_INTEGRATION_TEST?=integration
 GOMODULES=on
 UTILITY_BIN_PATH?=${WORKDIR}/.bin
 
-SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "./vendor/*")
+SRC:=$(shell find "${WORKDIR}" -type f -name "*.go" -not -path "*/vendor/*")
 
 # debian stuff
 DEBIAN_BUILD_DIR=$(BUILD_DIR)/deb
@@ -62,6 +62,10 @@ $(ETCGROUP): $(TMP_DIR)
 
 $(UTILITY_BIN_PATH):
 	@mkdir -p $@
+
+# Subdirectories of workdir where no mocks should be generated.
+# Multiple directories can be separated by space, comma or whatever is not a word to regex.
+MOCKERY_IGNORED=vendor,build,docs
 
 ##@ General
 

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -118,7 +118,7 @@ spec:
               http://etcd.$(MY_POD_NAMESPACE).svc.cluster.local:4001"
               # yamllint enable rule:line-length
             - name: ETCD_LISTEN_CLIENT_URLS
-              value: "http://0.0.0.0:4001"
+              value: "http://0.0.0.0:4001,http://0.0.0.0:2379"
             - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
               value: "http://$(MY_POD_NAME).etcd-headless.ecosystem.svc.cluster.local:2380"
             - name: ETCD_LISTEN_PEER_URLS

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -120,7 +120,7 @@ spec:
             - name: ETCD_LISTEN_CLIENT_URLS
               value: "http://0.0.0.0:4001,http://0.0.0.0:2379"
             - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
-              value: "http://$(MY_POD_NAME).etcd-headless.ecosystem.svc.cluster.local:2380"
+              value: "http://$(MY_POD_NAME).etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local:2380"
             - name: ETCD_LISTEN_PEER_URLS
               value: "http://0.0.0.0:2380"
             - name: ETCD_CLUSTER_DOMAIN

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -13,7 +13,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - name: client
-      port: 4001
+      port: 2379
       targetPort: client
     - name: peer
       port: 2380
@@ -32,7 +32,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 4001
-      targetPort: 2379
+      targetPort: client
   selector:
     app.kubernetes.io/name: etcd
 ---
@@ -114,7 +114,7 @@ spec:
               value: "yes"
             - name: ETCD_ADVERTISE_CLIENT_URLS
               # yamllint disable rule:line-length
-              value: "http://$(MY_POD_NAME).etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local:4001,\
+              value: "http://$(MY_POD_NAME).etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local:2379,\
               http://etcd.$(MY_POD_NAMESPACE).svc.cluster.local:4001"
               # yamllint enable rule:line-length
             - name: ETCD_LISTEN_CLIENT_URLS

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -1,3 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-headless
+  labels:
+    app: ces
+    app.kubernetes.io/name: etcd
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: client
+      port: 2379
+      targetPort: client
+    - name: peer
+      port: 2380
+      targetPort: peer
+  selector:
+    app.kubernetes.io/name: etcd
 ---
 apiVersion: v1
 kind: Service
@@ -9,9 +31,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: "client"
-      port: 4001
-      targetPort: client
+    - port: 4001
+      targetPort: 2379
   selector:
     app.kubernetes.io/name: etcd
 ---
@@ -51,7 +72,7 @@ spec:
       serviceAccountName: "default"
       containers:
         - name: etcd
-          image: docker.io/bitnami/etcd:3.5.4-debian-11-r30
+          image: docker.io/bitnami/etcd:3.5.7-debian-11-r22
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -69,6 +90,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_STS_NAME
+              value: "etcd"
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -92,13 +115,22 @@ spec:
             - name: ETCD_ADVERTISE_CLIENT_URLS
               # yamllint disable rule:line-length
               value: "http://$(MY_POD_NAME).etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local:2379,\
-              http://etcd.$(MY_POD_NAMESPACE).svc.cluster.local:4001"
+              http://etcd.$(MY_POD_NAMESPACE).svc.cluster.local:2379"
               # yamllint enable rule:line-length
             - name: ETCD_LISTEN_CLIENT_URLS
-              value: "http://0.0.0.0:2379"
+              value: "http://0.0.0.0:4001"
+            - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
+              value: "http://$(MY_POD_NAME).etcd-headless.ecosystem.svc.cluster.local:2380"
+            - name: ETCD_LISTEN_PEER_URLS
+              value: "http://0.0.0.0:2380"
+            - name: ETCD_CLUSTER_DOMAIN
+              value: "etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local"
           ports:
             - name: client
               containerPort: 2379
+              protocol: TCP
+            - name: peer
+              containerPort: 2380
               protocol: TCP
           livenessProbe:
             exec:
@@ -113,6 +145,7 @@ spec:
             exec:
               command:
                 - /opt/bitnami/scripts/etcd/healthcheck.sh
+            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             successThreshold: 1

--- a/manifests/etcd.yaml
+++ b/manifests/etcd.yaml
@@ -13,7 +13,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - name: client
-      port: 2379
+      port: 4001
       targetPort: client
     - name: peer
       port: 2380
@@ -114,8 +114,8 @@ spec:
               value: "yes"
             - name: ETCD_ADVERTISE_CLIENT_URLS
               # yamllint disable rule:line-length
-              value: "http://$(MY_POD_NAME).etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local:2379,\
-              http://etcd.$(MY_POD_NAMESPACE).svc.cluster.local:2379"
+              value: "http://$(MY_POD_NAME).etcd-headless.$(MY_POD_NAMESPACE).svc.cluster.local:4001,\
+              http://etcd.$(MY_POD_NAMESPACE).svc.cluster.local:4001"
               # yamllint enable rule:line-length
             - name: ETCD_LISTEN_CLIENT_URLS
               value: "http://0.0.0.0:4001"


### PR DESCRIPTION
Use correct advertise url to decrease startup time for the initial cluster creation. Increase the delay of the readinessprobe to 10 seconds because the regular startup lasts 3 seconds. Add headless service for the pods of the statefulset. Upgrade etcd to etcd:3.5.7-debian-11-r22.

Resolves #11 